### PR TITLE
Delegate LDAP attributes to LdapUser

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'factory_bot', '~> 5.1'
   gem 'factory_bot_rails', '~> 5.1'
+  gem 'faker'
   gem 'figaro'
   gem 'pry', '~> 0.12.2'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,8 @@ GEM
     factory_bot_rails (5.1.1)
       factory_bot (~> 5.1.0)
       railties (>= 4.2.0)
+    faker (2.11.0)
+      i18n (>= 1.6, < 2)
     ffi (1.12.2)
     figaro (1.1.1)
       thor (~> 0.14)
@@ -327,6 +329,7 @@ DEPENDENCIES
   doorkeeper-openid_connect (~> 1.7)
   factory_bot (~> 5.1)
   factory_bot_rails (~> 5.1)
+  faker
   figaro
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -3,32 +3,10 @@
 class UserController < ApplicationController
   before_action :doorkeeper_authorize!
 
+  # TODO what happens when user doesn't exist?
+  # TODO what happens when LDAP is down?
   def show
-    render json: current_resource_owner, status: :ok
-  end
-
-  def current_resource_owner
-    return {} unless doorkeeper_token
-
-    # TODO move this into a class? Or maybe just a .json view?
-    # TODO what happens when user doesn't exist?
-    # TODO what happens when LDAP is down?
-    # TODO keep the Hash#merge below, or be more explicit about which individual
-    #      keys we are returning in the response?
     user = User.find(doorkeeper_token.resource_owner_id)
-    ldap_response = PsuLdapService.find(user.access_id)
-
-    {
-      uid: user.access_id,
-      email: user.email,
-      surname: ldap_response[:surname],
-      given_name: ldap_response[:given_name],
-      last_name: ldap_response[:last_name],
-      first_name: ldap_response[:first_name],
-      primary_affiliation: ldap_response[:primary_affiliation],
-      groups: ldap_response[:groups],
-      access_id: ldap_response[:access_id],
-      admin_area: ldap_response[:admin_area]
-    }
+    render json: user, status: :ok
   end
 end

--- a/app/models/ldap_user.rb
+++ b/app/models/ldap_user.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class LdapUser
+  def self.attributes
+    %i(
+      groups
+      surname
+      last_name
+      given_name
+      first_name
+      primary_affiliation
+      uid
+      admin_area
+    )
+  end
+
+  # @param [Net::LDAP::Entry, Hash] ldap_entry
+  def initialize(ldap_entry = nil)
+    @ldap_entry = ldap_entry || Net::LDAP::Entry.new
+  end
+
+  def groups
+    @ldap_entry[:psmemberof].map do |group|
+      group.force_encoding('UTF-8').to_s
+    end
+  end
+
+  def surname
+    @ldap_entry[:sn].first
+  end
+  alias_method :last_name, :surname
+
+  def given_name
+    @ldap_entry[:givenname].first
+  end
+  alias_method :first_name, :given_name
+
+  def primary_affiliation
+    @ldap_entry[:edupersonprimaryaffiliation].first
+  end
+
+  def uid
+    @ldap_entry[:uid].first
+  end
+
+  def admin_area
+    @ldap_entry[:psadminarea].first
+  end
+end

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -15,8 +15,9 @@ RSpec.describe UserController, type: :controller do
       end
 
       it 'returns information about the user' do
-        expect(response).to be_success
+        expect(response).to be_successful
         expect(json['email']).to eq(user.email)
+        expect(json['given_name']).to eq(user.given_name)
       end
     end
 

--- a/spec/factories/ldap_users.rb
+++ b/spec/factories/ldap_users.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require Rails.root.join('spec/support/factory_bot_helpers')
+
+FactoryBot.define do
+  factory :ldap_user do
+    skip_create
+
+    transient do
+      groups { Array.new(3) { "cn=up.libraries.#{Faker::Currency.code.downcase},dc=psu,dc=edu" } }
+      surname { Faker::Name.last_name }
+      last_name { surname }
+      given_name { Faker::Name.first_name }
+      first_name { given_name }
+      primary_affiliation { 'STAFF' }
+      access_id { FactoryBotHelpers.generate_access_id }
+      admin_area { 'University Libraries' }
+    end
+
+    initialize_with do
+      # @note LdapUser takes a Net::LDAP::Entry for an argument. We can mock it by using a hash.
+      new(
+        psmemberof: groups.map(&:dup),
+        sn: [surname],
+        givenname: [given_name],
+        edupersonprimaryaffiliation: [primary_affiliation],
+        uid: [access_id],
+        psadminarea: [admin_area]
+      )
+    end
+
+    trait :is_admin do
+      groups { [User::DEFAULT_ADMIN_UMG] }
+    end
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,7 +4,7 @@ require Rails.root.join('spec/support/factory_bot_helpers')
 
 FactoryBot.define do
   factory :user do
-    access_id { generate_access_id }
+    access_id { FactoryBotHelpers.generate_access_id }
     email { "#{access_id}@psu.edu" }
     is_admin { false }
     password { SecureRandom.uuid }

--- a/spec/models/ldap_user_spec.rb
+++ b/spec/models/ldap_user_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LdapUser, type: :model do
+  describe '.attributes' do
+    subject { described_class }
+
+    its(:attributes) do
+      is_expected.to contain_exactly(
+        :groups,
+        :surname,
+        :last_name,
+        :given_name,
+        :first_name,
+        :primary_affiliation,
+        :uid,
+        :admin_area
+      )
+    end
+  end
+
+  describe 'attributes from the Net::LDAP:Entry' do
+    subject { described_class.new(user.instance_variable_get(:@ldap_entry)) }
+
+    let(:user) { build(:ldap_user) }
+
+    its(:groups) { is_expected.to eq(user.groups) }
+    its(:surname) { is_expected.to eq(user.surname) }
+    its(:last_name) { is_expected.to eq(user.last_name) }
+    its(:given_name) { is_expected.to eq(user.given_name) }
+    its(:first_name) { is_expected.to eq(user.first_name) }
+    its(:primary_affiliation) { is_expected.to eq(user.primary_affiliation) }
+    its(:uid) { is_expected.to eq(user.uid) }
+    its(:admin_area) { is_expected.to eq(user.admin_area) }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,57 +3,48 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  subject(:user) { described_class.create!(access_id: 'jqd123', is_admin: false) }
+  subject(:user) { create(:user) }
 
-  let(:ldap_mock_response) {
-    {
-      first_name: 'Joe',
-      last_name: 'Developer',
-      primary_affiliation: 'STAFF',
-      groups: [],
-      admin_area: 'UNIVERSITY LIBRARIES'
-    }
-  }
+  let(:ldap_user) { build(:ldap_user, access_id: user.access_id) }
 
-  before do
-    allow(PsuLdapService).to receive(:find).and_return(ldap_mock_response)
+  before { allow(PsuLdapService).to receive(:find).and_return(ldap_user) }
+
+  describe '#as_json' do
+    subject(:json) { user.as_json }
+
+    let(:json_keys) { LdapUser.attributes + [:access_id, :email] }
+
+    it 'uses a customized json representation' do
+      json_keys.each do |attribute|
+        expect(json).to include(attribute.to_s => user.send(attribute))
+      end
+    end
   end
 
   describe '#groups' do
-    context 'with an empty LDAP response' do
-      let(:ldap_mock_response) { {} }
-
-      its(:groups) { is_expected.to eq([]) }
-    end
-
-    context 'when the user is a member of a group' do
-      let(:ldap_mock_response) { { groups: ['mygroup'] } }
-
-      its(:groups) { is_expected.to eq(['mygroup']) }
-    end
-
-    context 'when the response is a string' do
-      let(:ldap_mock_response) { { groups: 'mystringgroup' } }
-
-      its(:groups) { is_expected.to eq(['mystringgroup']) }
+    its(:groups) do
+      is_expected.to eq(ldap_user.groups)
+      is_expected.not_to be_empty
     end
   end
 
   describe '#surname' do
-    let(:ldap_mock_response) { { surname: 'Jones' } }
-
-    its(:surname) { is_expected.to eq('Jones') }
+    its(:surname) do
+      is_expected.to eq(ldap_user.surname)
+      is_expected.not_to be_nil
+    end
   end
 
   describe '#given_name' do
-    let(:ldap_mock_response) { { given_name: 'Indiana' } }
-
-    its(:given_name) { is_expected.to eq('Indiana') }
+    its(:given_name) do
+      is_expected.to eq(ldap_user.given_name)
+      is_expected.not_to be_nil
+    end
   end
 
   describe '#populate_ldap_attributes' do
     context 'when the user is a member of the admin group' do
-      before { ldap_mock_response[:groups] = ['cn=umg/up.ul.dsrd.sudoers,dc=psu,dc=edu'] }
+      let(:ldap_user) { build(:ldap_user, :is_admin, access_id: user.access_id) }
 
       it 'updates the user, setting is_admin to true' do
         expect { user.populate_ldap_attributes }
@@ -64,8 +55,6 @@ RSpec.describe User, type: :model do
     end
 
     context 'when the user is not a member of the admin group' do
-      before { ldap_mock_response[:groups] = ['cn=umg/hosers'] }
-
       it 'does not set the user to be an admin' do
         expect { user.populate_ldap_attributes }
           .not_to change { user.reload.is_admin }

--- a/spec/services/psu_ldap_service_spec.rb
+++ b/spec/services/psu_ldap_service_spec.rb
@@ -4,33 +4,48 @@ require 'rails_helper'
 
 RSpec.describe PsuLdapService do
   describe '.find' do
-    subject(:attrs) { described_class.find(user_id) }
+    subject { described_class.find(user_id) }
 
     context 'given a valid psu user id' do
       let(:user_id) { 'djb44' }
 
-      it 'returns a result' do
-        expect(attrs[:access_id]).to eq('djb44')
-        expect(attrs[:last_name]).to eq('Bohn')
-        expect(attrs[:first_name]).to eq('Dann')
-        expect(attrs[:surname]).to eq('Bohn')
-        expect(attrs[:given_name]).to eq('Dann')
-        expect(attrs[:primary_affiliation]).to eq 'STAFF'
-        expect(attrs[:groups]).to include('cn=psu.up.all,dc=psu,dc=edu')
-        expect(attrs[:admin_area]).to be_a(String)
-      end
+      it { is_expected.to be_a(LdapUser) }
+      its(:uid) { is_expected.to eq('djb44') }
+      its(:last_name) { is_expected.to eq('Bohn') }
+      its(:first_name) { is_expected.to eq('Dann') }
+      its(:surname) { is_expected.to eq('Bohn') }
+      its(:given_name) { is_expected.to eq('Dann') }
+      its(:primary_affiliation) { is_expected.to eq 'STAFF' }
+      its(:groups) { is_expected.to include('cn=psu.up.all,dc=psu,dc=edu') }
+      its(:admin_area) { is_expected.to be_a(String) }
     end
 
     context 'given a bogus psu user id' do
       let(:user_id) { 'completelybogus' }
 
-      it { is_expected.to eq({}) }
+      it { is_expected.to be_a(LdapUser) }
+      its(:uid) { is_expected.to be_nil }
+      its(:last_name) { is_expected.to be_nil }
+      its(:first_name) { is_expected.to be_nil }
+      its(:surname) { is_expected.to be_nil }
+      its(:given_name) { is_expected.to be_nil }
+      its(:primary_affiliation) { is_expected.to be_nil }
+      its(:groups) { is_expected.to be_empty }
+      its(:admin_area) { is_expected.to be_nil }
     end
 
     context 'given a nul user id' do
       let(:user_id) { nil }
 
-      it { is_expected.to eq({}) }
+      it { is_expected.to be_a(LdapUser) }
+      its(:uid) { is_expected.to be_nil }
+      its(:last_name) { is_expected.to be_nil }
+      its(:first_name) { is_expected.to be_nil }
+      its(:surname) { is_expected.to be_nil }
+      its(:given_name) { is_expected.to be_nil }
+      its(:primary_affiliation) { is_expected.to be_nil }
+      its(:groups) { is_expected.to be_empty }
+      its(:admin_area) { is_expected.to be_nil }
     end
 
     context 'given a specially malformed user id' do

--- a/spec/support/factory_bot_helpers.rb
+++ b/spec/support/factory_bot_helpers.rb
@@ -4,6 +4,6 @@ module FactoryBotHelpers
   def self.generate_access_id
     alphabet = ('a'..'z').to_a
 
-    format("#{alphabet.sample(3)}#{rand(100)}")
+    format("#{alphabet.sample(3).join}#{rand(100)}")
   end
 end


### PR DESCRIPTION
Creates a new LdapUser class that wraps the result from PsuLdapService so we can interact with its attributes more easily. The User class then delegates the methods it needs to this class, enabling us to use the built-in ActiveModel::Serializers for json representations of user data. This cleans up the UserController by ceding all of that logic to the User class.

In the process, there's a lot of refactoring and some additional gems like Faker to aid in the testing.